### PR TITLE
[FEAT] Added three functions to display basic glider statistics

### DIFF
--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -60,7 +60,48 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds"
+    "ds\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b93a2ef",
+   "metadata": {},
+   "source": [
+    "# Basic statistics of dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6fd094f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Basic plot of the location of the dataset in space/time\n",
+    "tools.plot_glider_track(ds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "620e5523",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Basic diagnostics of the gridding in the dataset\n",
+    "tools.plot_grid_spacing_histograms(ds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6bf7fb8d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Basic diagnostics of the watermass properties\n",
+    "tools.plot_ts_histograms(ds)\n"
    ]
   },
   {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,3 +17,4 @@ nbconvert
 sphinx
 sphinx-rtd-theme
 cartopy
+gsw

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,3 +16,4 @@ nbsphinx
 nbconvert
 sphinx
 sphinx-rtd-theme
+cartopy

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ skyfield
 tqdm
 gsw
 sgp4>=2.14
+cartopy


### PR DESCRIPTION
I've added 3 functions which display information I typically want to know about a dataset. I don't know if it's really a part of glidertest, but

Map of the glider track (uses Cartopy - I am guessing we should try to minimise the numbers of packages required, so I could rewrite this without Cartopy)
Histograms of depth/time spacing of the data. This is something that will give the user a Quick Look at whether the dataset have been gridded in some way, and or whether the spacing is fine enough to allow for vertical velocity/spectral work
Histogram of temperature/salinity. (This requires gsw - I think we will need something to calculate density so this package probably should be added to requirements.)