### PR TITLE
[TESTS] test of monotony

### DIFF
--- a/glidertest/tools.py
+++ b/glidertest/tools.py
@@ -552,8 +552,10 @@ def check_monotony(da):
     """
     if not pd.Series(da).is_monotonic_increasing:
         print(f'{da.name} is not always monotonically increasing')
+        return False
     else:
         print(f'{da.name} is always monotonically increasing')
+        return True
 
 
 def plot_profIncrease(ds: xr.DataArray, ax: plt.Axes = None, **kw: dict, ) -> tuple({plt.Figure, plt.Axes}):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -43,3 +43,11 @@ def test_profile_check():
     ds = fetchers.load_sample_dataset()
     tools.check_monotony(ds.PROFILE_NUMBER)
     tools.plot_profIncrease(ds)
+
+def test_check_monotony():
+    ds = fetchers.load_sample_dataset()
+    profile_number_monotony = tools.check_monotony(ds.PROFILE_NUMBER)
+    temperature_monotony = tools.check_monotony(ds.TEMP)
+    assert profile_number_monotony
+    assert not temperature_monotony
+    


### PR DESCRIPTION
This is an example of a unit test. Note that I have made a small addition to `tools.check_monotony`. As well as printing the result, it will return True or False depending on if the passed variables is monotonically increasing or not

I have added a test that runs `tools.check_monotony` on two variables, PROFILE_NUMBER and TEMP, that we expect to pass and fail respectively.

```python
def test_check_monotony():
    ds = fetchers.load_sample_dataset()
    profile_number_monotony = tools.check_monotony(ds.PROFILE_NUMBER)
    temperature_monotony = tools.check_monotony(ds.TEMP)
    assert profile_number_monotony
    assert not temperature_monotony
```

I then check those results with `assert`. `assert` is the key here. If you try to `assert` something that is not True like `assert 1 + 1 == 3` it will fail. This way we test that, not only does `tools.check_monotony` run, it returns a verifiable result. This gives us a high degree of certainty that future edits will not change the behavior of `tools.check_monotony without the tests failing and alerting us.