### PR TITLE
[FEAT] check for essential vars and raise KeyError

### DIFF
--- a/glidertest/tools.py
+++ b/glidertest/tools.py
@@ -231,9 +231,6 @@ def optics_first_check(ds, var='CHLA'):
     This function returns plots and text
     """
     _necessary_variables_check(ds, [var, 'TIME', 'DEPTH'])
-    if var not in ds.variables:
-        msg = f"{var} does not exist in the dataset. Make sure the spelling is correct or add this variable to your dataset"
-        raise ValueError(msg)
     # Check how much negative data there is
     neg_chl = np.round((len(np.where(ds[var] < 0)[0]) * 100) / len(ds[var]), 1)
     if neg_chl > 0:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,3 +1,4 @@
+import pytest
 from glidertest import fetchers, tools
 import matplotlib.pyplot as plt
 
@@ -16,10 +17,11 @@ def test_up_down_bias():
 
 def test_chl():
     ds = fetchers.load_sample_dataset()
-    if 'CHLA' in ds.variables:
-        tools.optics_first_check(ds, var='CHLA')
-    if 'BBP700' in ds.variables:
-        tools.optics_first_check(ds, var='BBP700')
+    tools.optics_first_check(ds, var='CHLA')
+    tools.optics_first_check(ds, var='BBP700')
+    with pytest.raises(KeyError) as e:
+        tools.optics_first_check(ds, var='nonexistent_variable')
+
 
 def test_quench_sequence():
     ds = fetchers.load_sample_dataset()
@@ -34,10 +36,8 @@ def test_quench_sequence():
 def test_temporal_drift():
     ds = fetchers.load_sample_dataset()
     fig, ax = plt.subplots(1, 2)
-    if 'DOXY' in ds.variables:
-        tools.check_temporal_drift(ds,'DOXY', ax)
-    if 'CHLA' in ds.variables:
-        tools.check_temporal_drift(ds,'CHLA')
+    tools.check_temporal_drift(ds,'DOXY', ax)
+    tools.check_temporal_drift(ds,'CHLA')
         
 def test_profile_check():
     ds = fetchers.load_sample_dataset()


### PR DESCRIPTION
This PR adds a new function `_necessary_variables_check()` which takes a dataset and list of variables and raises a KeyError if any of those variables are not found in the dataset. This function is called at the beginning of many of the `glidertest.tools` functions to check that key variables are present.

**Why raise a KeyError rather than printing a message and returning?** This forces the user to do something about the error, either adding the necessary variable, or not running that test. This prevents "silent failure" where a user runs e.g. a chlorophyll drift check with an incorrectly named chlorophyll var and doesn't get a report showing that the sensor drifts. The script should fail if a function cannot run. It also fails *fast* right at the beginning of the function

**Why have a separate function rather than just `if not <var_name> in dataset`? Within the main function** Separating this out to a dedicated function makes it easier to change (e.g. the error message) as it is all in one place

**Why does the function name start with `_`?** A leading `_` marks this as a private function in the library. This means that it will not show up in autocomplete, as part of the docs etc. as there is no reason for the end user to want to run the function (though they still can if they want!)

**What does it look like in practice?**

![image](https://github.com/user-attachments/assets/6f803b6b-b35b-4fac-aa2d-23811c377ead)

much like the error you get trying to use a variable in an xarray dataset that doesn't exist

**Won't this break my workflow??** Yes! If your workflow was to run all functions and ignore failures. One should ideally have checks in place like

```
if 'BBP700' in ds.variables():
    tools.optics_first_check(ds, var='BBP700')
```


This resolves #52