### PR TITLE
deploy docs on merge of PR

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Deploy
 
-      if: success() && github.event_name == 'release'
+      if: success() && github.event.pull_request.merged
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will rebuild the docs each time a PR is merged, so that they keep up with the current state of the repo rather than the latest release