### PR TITLE
[FIX BUG] Axis labels are wrong when ytick are not fixed

### DIFF
--- a/glidertest/plots.py
+++ b/glidertest/plots.py
@@ -1195,8 +1195,7 @@ def plot_ioosqc(data, suspect_threshold=[25], fail_threshold=[50], title='', ax=
         else:
             a_2[1] = f'x<{suspect_threshold[0]}'
         if len(fail_threshold) > 1:
-            a_2[
-                3] = f'{suspect_threshold[1]}<x<{fail_threshold[1]} &\n {fail_threshold[0]}<x<{suspect_threshold[0].values}'
+            a_2[3] = f'{suspect_threshold[1]}<x<{fail_threshold[1]} &\n {fail_threshold[0]}<x<{suspect_threshold[0].values}'
             a_2[4] = f'x<{fail_threshold[0]} or \nx>{fail_threshold[1]}'
         else:
             a_2[3] = f'x>{suspect_threshold[0]} and \nx<{fail_threshold[0]}'

--- a/glidertest/plots.py
+++ b/glidertest/plots.py
@@ -1181,20 +1181,22 @@ def plot_ioosqc(data, suspect_threshold=[25], fail_threshold=[50], title='', ax=
             force_plot = False
 
         ax.scatter(np.arange(len(data)), data, s=4)
+        ax.set_yticks([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         a = ax.get_yticks().tolist()
-        a[1:] = ['GOOD', 'UNKNOWN', 'SUSPECT', 'FAIL', '', '', '', '', 'MISSING']
+        a[:] = ['', 'GOOD', 'UNKNOWN', 'SUSPECT', 'FAIL', '', '', '', '', 'MISSING', '']
         ax.set_yticklabels(a)
         ax2 = ax.twinx()
         ax2.scatter(np.arange(len(data)), data, s=4)
-
+        ax2.set_yticks([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         a_2 = ax2.get_yticks().tolist()
-        a_2[1:] = ['', '', '', '', '', '', '', '', '']
+        a_2[:] = ['', '', '', '', '', '', '', '', '', '', '']
         if len(suspect_threshold) > 1:
             a_2[1] = f'x>{suspect_threshold[0]} or \nx<{suspect_threshold[1]}'
         else:
             a_2[1] = f'x<{suspect_threshold[0]}'
         if len(fail_threshold) > 1:
-            a_2[3] = f'{suspect_threshold[1]}<x<{fail_threshold[1]} &\n {fail_threshold[0]}<x<{suspect_threshold[0].values}'
+            a_2[
+                3] = f'{suspect_threshold[1]}<x<{fail_threshold[1]} &\n {fail_threshold[0]}<x<{suspect_threshold[0].values}'
             a_2[4] = f'x<{fail_threshold[0]} or \nx>{fail_threshold[1]}'
         else:
             a_2[3] = f'x>{suspect_threshold[0]} and \nx<{fail_threshold[0]}'
@@ -1202,6 +1204,7 @@ def plot_ioosqc(data, suspect_threshold=[25], fail_threshold=[50], title='', ax=
         a_2[9] = 'Nan'
 
         ax2.set_yticklabels(a_2, fontsize=12)
+
         ax.set_xlabel('Data Index')
         ax.grid()
         ax.set_title(title)


### PR DESCRIPTION
For the IOOS qc plots in case we have no good data or we do not have a tick for every point, then the new labels are assigned wrong. I am not forcing ticks to always be from 0 to 10 so we assign the new labels correctly